### PR TITLE
Update lower bounds of fmt and yojson

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -20,6 +20,6 @@
   (alcotest :with-test)
   astring
   curly
-  fmt
-  yojson
+  (fmt (>= 0.8.7))
+  (yojson (>= 1.6))
   (ocaml (>= 4.08))))

--- a/get-activity-lib.opam
+++ b/get-activity-lib.opam
@@ -10,8 +10,8 @@ depends: [
   "alcotest" {with-test}
   "astring"
   "curly"
-  "fmt"
-  "yojson"
+  "fmt" {>= "0.8.7"}
+  "yojson" {>= "1.6"}
   "ocaml" {>= "4.08"}
   "odoc" {with-doc}
 ]


### PR DESCRIPTION
Fix the `lower bound` target of ocaml-ci