### PR TITLE
Remove unused field: PR review comments

### DIFF
--- a/lib/contributions.ml
+++ b/lib/contributions.ml
@@ -39,7 +39,6 @@ let query user =
             pullRequest { title }
             body
             state
-            comments(first: 100) { nodes { body } }
             repository { nameWithOwner }
           }
         }

--- a/test/lib/test_contributions.ml
+++ b/test/lib/test_contributions.ml
@@ -124,7 +124,6 @@ let request ~user =
             pullRequest { title }
             body
             state
-            comments(first: 100) { nodes { body } }
             repository { nameWithOwner }
           }
         }
@@ -267,9 +266,6 @@ let activity_example ~user =
                 },
                 "body": "xxx",
                 "state": "APPROVED",
-                "comments": {
-                  "nodes": []
-                },
                 "repository": {
                   "nameWithOwner": "realworldocaml/mdx"
                 }
@@ -284,9 +280,6 @@ let activity_example ~user =
                 },
                 "body": "xxx",
                 "state": "APPROVED",
-                "comments": {
-                  "nodes": []
-                },
                 "repository": {
                   "nameWithOwner": "tarides/okra"
                 }


### PR DESCRIPTION
This field was not extracted into the activity, not sure this is very useful to have anyway. We will extract review comments, and regular comments on those PRs instead.