### PR TITLE
Filter out null elements that are sometimes in the nodes list

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+## unreleased
+
+### Fixed
+
+- Filter out null elements that are sometimes in the nodes list (#<PR_NUMBER>, @gpetiot)
+
 ## 2.0.0
 
 ### Fixed

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 
 ### Fixed
 
-- Filter out null elements that are sometimes in the nodes list (#<PR_NUMBER>, @gpetiot)
+- Filter out null elements that are sometimes in the nodes list (#39, @gpetiot)
 
 ## 2.0.0
 

--- a/lib/contributions_json_response.ml
+++ b/lib/contributions_json_response.ml
@@ -7,7 +7,7 @@ module Repository = struct
   type contribution = { occurredAt : string; repository : t }
   [@@deriving yojson]
 
-  type contributions = { nodes : contribution list } [@@deriving yojson]
+  type contributions = { nodes : contribution option list } [@@deriving yojson]
 end
 
 module Issue = struct
@@ -21,13 +21,13 @@ module Issue = struct
 
   type title = { title : string } [@@deriving yojson]
   type contribution = { occurredAt : string; issue : t } [@@deriving yojson]
-  type contributions = { nodes : contribution list } [@@deriving yojson]
+  type contributions = { nodes : contribution option list } [@@deriving yojson]
 end
 
 module PullRequest = struct
   type actor = { login : string } [@@deriving yojson]
   type timelineItem = { createdAt : string; actor : actor } [@@deriving yojson]
-  type timelineItems = { nodes : timelineItem list } [@@deriving yojson]
+  type timelineItems = { nodes : timelineItem option list } [@@deriving yojson]
 
   type t = {
     url : string;
@@ -43,7 +43,7 @@ module PullRequest = struct
   type contribution = { occurredAt : string; pullRequest : t }
   [@@deriving yojson]
 
-  type contributions = { nodes : contribution list } [@@deriving yojson]
+  type contributions = { nodes : contribution option list } [@@deriving yojson]
 
   module Review = struct
     type t = {
@@ -58,7 +58,8 @@ module PullRequest = struct
     type contribution = { occurredAt : string; pullRequestReview : t }
     [@@deriving yojson]
 
-    type contributions = { nodes : contribution list } [@@deriving yojson]
+    type contributions = { nodes : contribution option list }
+    [@@deriving yojson]
   end
 end
 
@@ -71,7 +72,7 @@ type comment = {
 }
 [@@deriving yojson]
 
-type comments = { nodes : comment list } [@@deriving yojson]
+type comments = { nodes : comment option list } [@@deriving yojson]
 
 type contributionsCollection = {
   issueContributions : Issue.contributions;

--- a/test/lib/test_contributions.ml
+++ b/test/lib/test_contributions.ml
@@ -287,7 +287,8 @@ let activity_example ~user =
                   ]
                 }
               }
-            }
+            },
+            null
           ]
         },
         "pullRequestReviewContributions": {


### PR DESCRIPTION
Fix #32 

The code replaced by #26 was indeed filtering the list of nodes from Null elements

The weird thing is that apparently these nulls are only produced for some people and not others, e.g. if I try to retrieve the exact same period for Jan it works for me, but fails for him.